### PR TITLE
Remove printlns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ impl Yin {
             tau_min,
             sample_rate,
         };
-        println!("{:?}", res);
         res
     }
 
@@ -66,7 +65,6 @@ fn cmndf(raw_diff: &[f64]) -> Vec<f64> {
 
 fn compute_diff_min(diff_fn: &[f64], min_tau: usize, max_tau: usize, harm_threshold: f64) -> usize {
     let mut tau = min_tau;
-    println!("Max_tau {}", max_tau);
     while tau < max_tau {
         if diff_fn[tau] < harm_threshold {
             while tau + 1 < max_tau && diff_fn[tau + 1] < diff_fn[tau] {
@@ -100,7 +98,6 @@ pub fn compute_sample_frequency(
     let diff_fn = diff_function(&audio_sample, tau_max);
     let cmndf = cmndf(&diff_fn);
     let sample_period = compute_diff_min(&cmndf, tau_min, tau_max, threshold);
-    println!("{}", sample_period);
     convert_to_frequency(&diff_fn, tau_max, sample_period, sample_rate)
 }
 


### PR DESCRIPTION
These prints seem to just be for debugging and print values returned by the functions. Removing them would be better for users of the crate cleaning up their programs output as well as providing a minor performance improvement (this provided a 1ms improvement per iteration for me ~28% improvement on average (3.8ms to 2.7ms average).

Personally, if the debug printing is desired I'd probably keep it to an example project (I didn't check them to see if it was there), or bring in something like the log crate and use the `debug!` macro so it can be easily reenabled and the cost can be avoided in released software :eyes: 